### PR TITLE
Fix #8

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -80,6 +80,16 @@ body {
 
 }
 
+@media screen and (max-width: 460px) {
+  .header-image img {
+  	width: 300px;
+  }
+    
+    #header-image-wrapper img {
+      width: 300px;
+    }
+}
+
 .dropdown-menu li {
 	background: transparent;
 }


### PR DESCRIPTION
Add @media query that shrinks header images on devices with screen sizes < 460px to avoid hamburger menu overlaying them.
